### PR TITLE
Emacs

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,10 +1,19 @@
 * Nix/NixOS Configuration Monorepo
+[[https://akirak.cachix.org][file:https://img.shields.io/badge/cachix-akirak-blue.svg]]
+
 This is a monorepo for my Nix configuration files.
 ** Features
 - The entire =flake.nix= is organized using [[https://github.com/gytis-ivaskevicius/flake-utils-plus][flake-utils-plus]]
 - Manage user preferences using [[https://github.com/nix-community/home-manager][home-manager]]
 - Configure Emacs using [[https://github.com/akirak/emacs-twist][emacs-twist]] and each session is sandboxed using [[https://github.com/containers/bubblewrap][bubblewrap]]
 ** Usage
+*** Trying out the Emacs configuration
+Emacs with native compilation takes a lot of time to build, but I sometimes push the Emacs executable to cachix, so you may be able to use the binary cache:
+
+#+begin_src sh
+cachix use akirak
+#+end_src
+
 If you are using Linux with Nix 2.4 installed, you can try out a sandboxed Emacs session:
 
 #+begin_src sh

--- a/emacs/.org-config.el
+++ b/emacs/.org-config.el
@@ -8,8 +8,7 @@
 (org-starter-def "emacs-config.org"
   :key "e"
   :refile (:maxlevel . 4)
-  :minor-modes (org-edna-mode
-                akirak-org-sort-buffer-mode))
+  :minor-modes (org-edna-mode))
 
 (akirak-org-capture-add-templates
     (cl-macrolet

--- a/emacs/README.org
+++ b/emacs/README.org
@@ -1,0 +1,23 @@
+* Emacs Configuration
+This is an Emacs configuration that uses [[https://github.com/akirak/emacs-twist][emacs-twist]] to manage package version.
+
+** Structure
+The following files configure Emacs Lisp packages:
+
+- [[file:emacs-config.org][emacs-config.org]]: The main configuration file.
+- [[file:compat.el][compat.el]]: A compatibility layer for myself. Its content is mostly keybindings I grew in [[https://github.com/akirak/emacs.d/][my previous config]].
+- [[file:extras.org][extras.org]]: A collection of extra configurations for specific contexts.
+
+The following files should be the contents of =user-emacs-directory=:
+
+- [[file:early-init.el][early-init.el]]
+- [[file:init.el][init.el]]
+
+The following files and directories are needed for building the configuration using Twist:
+
+- [[file:sources/][sources/]]: A directory for lock files.
+- [[file:recipes/][recipes/]]: Custom recipes for packages that are not available on any package registry.
+- [[file:inventories/flake.nix][inventories/flake.nix]]: Track registries of Emacs Lisp packages.
+
+[[file:.org-config.el][.org-config.el]] contains my Org configuration for maintaining the configuration. See [[file:emacs-config.org::#develop-org-configuration][a note]]
+for details.

--- a/emacs/emacs-config.org
+++ b/emacs/emacs-config.org
@@ -8,7 +8,7 @@
 - [[#performance][Performance]]
 - [[#built-ins][Built-ins]]
 - [[#basic-appearances][Basic appearances]]
-- [[#custom-variables][Custom variables]]
+- [[#custom-conventions][Custom conventions]]
 - [[#org][Org]]
 - [[#packages][Packages]]
 - [[#notes][Notes]]
@@ -16,11 +16,16 @@
   - [[#profiling][Profiling]]
 :END:
 ** Setup.el
+[[https://git.sr.ht/~pkal/setup][Setup.el]] is an alternative to the famous [[https://github.com/jwiegley/use-package][use-package]].
+I am interesting to see if it can reduce the amount of configuration code.
+
 #+begin_src emacs-lisp
   (eval-when-compile
     (require 'setup)
     (require 'cl-lib)
   
+    ;; Exactly the same definition as a snippet available at
+    ;; https://www.emacswiki.org/emacs/SetupEl#h5o-4 but renamed
     (defmacro define-setup-macro (name signature &rest body)
       "Shorthand for `setup-define'.
     NAME is the name of the local macro.  SIGNATURE is used as the
@@ -135,7 +140,8 @@ You need to install the font separately.
                      (set-face-attribute face nil :family family)
                    (message "Font family %s is not installed" family)))))))
 #+end_src
-** Custom variables
+** Custom conventions
+*** Prefix for mode-specific commands
 #+begin_src emacs-lisp
   (defcustom akirak/mode-prefix-key "C-,"
     "Prefix for mode-specific keybindings."

--- a/emacs/emacs-config.org
+++ b/emacs/emacs-config.org
@@ -176,6 +176,7 @@ A bunch of useful packages are configured here.
 *** How to develop this configuration
 :PROPERTIES:
 :CREATED_TIME: [2022-01-02 Sun 14:52]
+:CUSTOM_ID: develop-org-configuration
 :END:
 This configuration is maintained in Org, and [[file:.org-config.el][.org-config.el]] contains the configuration for the Org file. It uses [[https://github.com/akirak/org-starter][org-starter]], which is my package for maintaining file-specific Org configuration.
 

--- a/emacs/emacs-config.org
+++ b/emacs/emacs-config.org
@@ -74,6 +74,9 @@ Display initialization time concisely at startup:
                        gcs-done)))
 #+end_src
 ** Built-ins
+:PROPERTIES:
+:SORTING_TYPE: a
+:END:
 # Note: These should never fail.
 
 #+begin_src emacs-lisp
@@ -103,6 +106,343 @@ Display initialization time concisely at startup:
 Resources:
 
 - https://github.com/minad/vertico#configuration
+*** autorevert                                                         :IO:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup autorevert
+    (global-auto-revert-mode t))
+#+end_src
+*** buffer.c                                        :formatting:visual:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+#+begin_src emacs-lisp
+  (setup buffer
+    (:option buffer-file-coding-system 'utf-8
+             fill-column 80
+             indicate-empty-lines t
+             truncate-lines t))
+#+end_src
+*** callproc.c                                                    :process:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup callproc
+    (:only-if (eq system-type 'windows-nt))
+    (:option shell-file-name (executable-find "bash")))
+#+end_src
+*** compile                                                       :process:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup compile
+    (:option
+     compilation-auto-jump-to-first-error t
+     compilation-scroll-output t
+     compilation-error-regexp-alist
+     (list
+      ;; eslint
+      (list (rx bol (group (or "ERROR" "WARNING"))
+                " in "
+                (group (*? anything))
+                ":" (group (+ digit))
+                ":" (group (+ digit)))
+            2 3 4 '(1 . 1))
+      ;; eslint --fix
+      (list (rx bol (group "/home/" (+ nonl)) "\n"
+                (+ space) (group (+ digit)) ":" (group (+ digit))
+                (+ space) (group (or "error" "WARNING")))
+            1 2 3 '(4 . 4))
+      ;; prettier
+      (list (rx bol "[" (group (or "error" "WARNING")) "] "
+                (group (*? anything))
+                ": "
+                (+ anything)
+                "(" (group (+ digit)) ":" (group (+ digit)) ")")
+            2 3 4 '(1 . 1))
+      ;; nix-linter
+      ;; Unused argument `hsuper` at default.nix:9:24-15:6
+      (list (rx " at " (group (+ (not (any ":"))))
+                ":" (group (+ digit)) ":" (group (+ digit))
+                "-" (+ digit) ":" (+ digit) eol)
+            1 2 3)
+      ;; hlint
+      ;; path:67:23-45:
+      (list (rx bol (group (any "/" alnum)
+                           (* (any "./" alnum)))
+                ":"
+                (group (+ digit)) ":" (group (+ digit))
+                "-"
+                (+ digit)
+                ":" (* space)
+                (group (or "Warning" "Suggestion"
+                           "warning" "error"))
+                ":" space (+ nonl))
+            1 2 3 '(4 . 4))
+      (list (rx bol (group (any "/" alnum)
+                           (* (any "./" alnum)))
+                ":"
+                "(" (group (+ digit)) "," (group (+ digit)) ")"
+                "-"
+                "(" (+ digit) "," (+ digit) ")"
+                ":" (* space)
+                (group (or "Warning" "Suggestion"
+                           "warning" "error"))
+                ":" space (+ nonl))
+            1 2 3 '(4 . 4))
+      ;; Emacs checkdoc/byte-compile, GHC, etc.
+      ;; path:line:col: error:
+      (list (rx (group (+ (not (any space ":")))) ":"
+                (group (+ digit)) ":" (group (+ digit))
+                ":" (* space)
+                (or "Error" "error" "warning") ":")
+            1 2 3 '(4 . 4))
+  
+      ;; Elixir iex
+      ;; ** (SyntaxError) xxx/xxx/xxx.ex:97:29: syntax error before: '{'
+      (list (rx bol (+ "*") "(" (+ anything) ")"
+                (group (+ (not (any space ":")))) ":"
+                (group (+ digit)) ":" (group (+ digit))
+                ":" (* space))
+            1 2 3 '(4 . 4))))
+    )
+#+end_src
+*** ediff-wind                                                       :diff:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup ediff-wind
+    (:option ediff-window-setup-function #'ediff-setup-windows-plain))
+#+end_src
+*** fileio.c                                                        :files:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup fileio
+    (:option delete-by-moving-to-trash t))
+#+end_src
+*** filelock.c                                                         :IO:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup filelock
+    ;; lock files will kill `npm start'
+    (:option create-lockfiles nil))
+#+end_src
+*** files                                                           :files:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup files
+    (:option backup-by-copying t
+             delete-old-versions t
+             version-control t
+             view-read-only t))
+#+end_src
+*** fns.c and xfns.c                                                   :UI:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup fns
+    (:option use-dialog-box nil))
+  
+  (setup xfns
+    (:option x-gtk-use-system-tooltips nil))
+#+end_src
+*** frame                                                          :visual:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup frame
+    (blink-cursor-mode -1))
+#+end_src
+*** hl-line                                                        :visual:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup hl-line
+    (:with-mode hl-line-mode
+      (:hook-into prog-mode-hook
+                  text-mode-hook)))
+#+end_src
+*** indent.c                                                   :formatting:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup indent
+    (defun akirak/turn-on-indent-tabs-mode ()
+      (interactive)
+      (setq indent-tabs-mode 1))
+  
+    (dolist (mode-hook '(makefile-mode-hook))
+      (add-hook mode-hook 'akirak/turn-on-indent-tabs-mode)))
+#+end_src
+*** mule
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup mule-cmds
+    (set-language-environment "UTF-8"))
+#+end_src
+*** paragraphs                                                       :text:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup paragraphs
+    (:option sentence-end-double-space nil))
+#+end_src
+*** paren                                                     :parentheses:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup paren
+    (show-paren-mode 1))
+#+end_src
+*** process.c                                                     :process:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup process
+    ;; Expand read-process-output-max for lsp-mode
+    (:option read-process-output-max (* 1024 1024)))
+#+end_src
+*** recentf                                                 :history:files:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup recentf
+    (recentf-mode 1)
+    (:option recentf-max-saved-items 200))
+#+end_src
+*** saveplace                                                     :history:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup saveplace
+    (save-place-mode 1))
+#+end_src
+*** subr                                                               :UI:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup subr
+    (fset 'yes-or-no-p 'y-or-n-p))
+#+end_src
+*** terminal.c                                                         :UI:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup terminal
+    (:option ring-bell-function 'ignore))
+#+end_src
+*** tooltip                                                            :UI:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup tooltip
+    (tooltip-mode -1))
+#+end_src
+*** vc-hooks                                                           :VC:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup vc-hooks
+    (:option vc-follow-symlinks t
+             vc-make-backup-files t))
+#+end_src
+*** view                                                       :navigation:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup view
+    (:option view-inhibit-help-message t)
+  
+    (:with-map View-mode-map
+      (:bind
+       [remap scroll-up-command] #'View-scroll-half-page-forward
+       [remap scroll-down-command] #'View-scroll-half-page-backward)))
+#+end_src
+*** window                                                     :navigation:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup window
+    (:option recenter-positions '(top middle bottom))
+  
+    (defun akirak/scroll-half-height (&optional window)
+      (/ (1- (window-height (or window (selected-window)))) 2))
+  
+    (:global
+     ;; TODO: scroll-other-window and scroll-other-window-down
+     [remap scroll-up-command]
+     (defun akirak/scroll-half-page-forward (&optional arg)
+       (interactive "P")
+       (if (numberp arg)
+           (scroll-up arg)
+         (scroll-up (akirak/scroll-half-height))))
+     [remap scroll-down-command]
+     (defun akirak/scroll-half-page-backward (&optional arg)
+       (interactive "P")
+       (if (numberp arg)
+           (scroll-down arg)
+         (scroll-down (akirak/scroll-half-height))))))
+#+end_src
+*** winner                                                        :history:
+:PROPERTIES:
+:CREATED_TIME: [2022-01-03 Mon 23:59]
+:END:
+
+#+begin_src emacs-lisp
+  (setup winner
+    (winner-mode 1))
+#+end_src
 ** Basic appearances                                                :visual:
 *** Theme packages                                        :packages:
 # Note: Theme packages don't depend on other packages, so they can be loaded earlier than others.
@@ -213,10 +553,21 @@ If you have [[https://github.com/alphapapa/org-ql/][org-ql]] installed, you can 
 
 #+RESULTS: tag-statistics
 | [[org-ql-search:tags:packages][packages]]       | 7 |
+| [[org-ql-search:tags:visual][visual]]         | 5 |
+| [[org-ql-search:tags:UI][UI]]             | 4 |
+| [[org-ql-search:tags:process][process]]        | 3 |
+| [[org-ql-search:tags:files][files]]          | 3 |
+| [[org-ql-search:tags:history][history]]        | 3 |
 | [[org-ql-search:tags:initialization][initialization]] | 2 |
-| [[org-ql-search:tags:visual][visual]]         | 2 |
+| [[org-ql-search:tags:IO][IO]]             | 2 |
+| [[org-ql-search:tags:formatting][formatting]]     | 2 |
+| [[org-ql-search:tags:navigation][navigation]]     | 2 |
 | [[org-ql-search:tags:profiling][profiling]]      | 1 |
 | [[org-ql-search:tags:performance][performance]]    | 1 |
+| [[org-ql-search:tags:diff][diff]]           | 1 |
+| [[org-ql-search:tags:text][text]]           | 1 |
+| [[org-ql-search:tags:parentheses][parentheses]]    | 1 |
+| [[org-ql-search:tags:VC][VC]]             | 1 |
 | [[org-ql-search:tags:git][git]]            | 1 |
 | [[org-ql-search:tags:usability][usability]]      | 1 |
 | [[org-ql-search:tags:keybindings][keybindings]]    | 1 |

--- a/emacs/emacs-config.org
+++ b/emacs/emacs-config.org
@@ -13,7 +13,7 @@
 - [[#packages][Packages]]
 - [[#notes][Notes]]
   - [[#how-to-develop-this-configuration][How to develop this configuration]]
-  - [[#profiling][Profiling]]
+  - [[#tag-statistics][Tag statistics]]
 :END:
 ** Setup.el
 [[https://git.sr.ht/~pkal/setup][Setup.el]] is an alternative to the famous [[https://github.com/jwiegley/use-package][use-package]].
@@ -175,7 +175,7 @@ A bunch of useful packages are configured here.
     (which-key-mode t)
     (which-key-setup-side-window-bottom))
 #+end_src
-** Notes
+** Notes                                                             :@note:
 :PROPERTIES:
 :TOC:      :depth 2
 :END:
@@ -191,9 +191,38 @@ The workflow is as follows:
 1. Use =org-capture= to add an entry with a source block to the configuration file.
 2. Add further configuration for the package using =setup= and set tags on the heading.
 3. Org entries are automatically sorted by package name when the buffer is saved.
-*** Profiling
+*** Tag statistics
+If you have [[https://github.com/alphapapa/org-ql/][org-ql]] installed, you can browse entries matching a tag by pressing =C-c C-o= on a link below:
+
+#+name: tag-statistics
+#+begin_src emacs-lisp :tangle no
+  (->> (org-ql-select (current-buffer)
+         '(and (level > 2)
+               (not (tags "ARCHIVE")))
+         :action '(org-get-tags))
+       (--filter (not (member "@note" it)))
+       (-flatten-n 1)
+       (-group-by #'identity)
+       (-map (pcase-lambda (`(,tag . ,items))
+               (cons tag (length items))))
+       (-sort (-on #'> #'cdr))
+       (-map (pcase-lambda (`(,tag . ,count))
+               (list (format "[[org-ql-search:tags:%s][%s]]" tag tag)
+                     count))))
+#+end_src
+
+#+RESULTS: tag-statistics
+| [[org-ql-search:tags:packages][packages]]       | 7 |
+| [[org-ql-search:tags:initialization][initialization]] | 2 |
+| [[org-ql-search:tags:visual][visual]]         | 2 |
+| [[org-ql-search:tags:profiling][profiling]]      | 1 |
+| [[org-ql-search:tags:performance][performance]]    | 1 |
+| [[org-ql-search:tags:git][git]]            | 1 |
+| [[org-ql-search:tags:usability][usability]]      | 1 |
+| [[org-ql-search:tags:keybindings][keybindings]]    | 1 |
+
+*** Profiling (org-ql dblock example)                    :noexport:ARCHIVE:
+
 #+BEGIN: org-ql :query "tags: profiling" :columns (heading)
-| Heading        |
-|----------------|
-| [[benchmark-init][benchmark-init]] |
+
 #+END:

--- a/emacs/inventories/flake.nix
+++ b/emacs/inventories/flake.nix
@@ -8,10 +8,6 @@
       url = "git+https://git.savannah.gnu.org/git/emacs/elpa.git?ref=main";
       flake = false;
     };
-    nongnu-elpa = {
-      url = "git+https://git.savannah.gnu.org/git/emacs/nongnu.git?ref=main";
-      flake = false;
-    };
     epkgs = {
       url = "github:emacsmirror/epkgs";
       flake = false;

--- a/flake.lock
+++ b/flake.lock
@@ -81,6 +81,32 @@
         "type": "github"
       }
     },
+    "flake-no-path": {
+      "inputs": {
+        "flake-utils": [
+          "utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": [
+          "pre-commit-hooks"
+        ]
+      },
+      "locked": {
+        "lastModified": 1640760003,
+        "narHash": "sha256-RSk04ywngUySPFC134+Jrjzy+78xrRwcR1Y8owoAjK4=",
+        "owner": "akirak",
+        "repo": "flake-no-path",
+        "rev": "6ff159016ab78e21e83be788375b6475a5f68f7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "akirak",
+        "repo": "flake-no-path",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1638122382,
@@ -242,14 +268,39 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": [
+          "utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1639823344,
+        "narHash": "sha256-jlsQb2y6A5dB1R0wVPLOfDGM0wLyfYqEJNzMtXuzCXw=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "ff9c0b459ddc4b79c06e19d44251daa8e9cd1746",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "emacs-inventories": "emacs-inventories",
         "emacs-overlay": "emacs-overlay",
+        "flake-no-path": "flake-no-path",
         "flake-utils-plus": "flake-utils-plus",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs_2",
         "org-babel": "org-babel",
+        "pre-commit-hooks": "pre-commit-hooks",
         "twist": "twist",
         "utils": "utils"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
     },
     "org-babel": {
       "locked": {
-        "lastModified": 1641108124,
-        "narHash": "sha256-/fOaoWn6vDs7VYwqnfrRze9bBZMdNb0yYHnY62osJ0o=",
+        "lastModified": 1641201870,
+        "narHash": "sha256-mEkzFnjFSbdWkV0kmjSgYyPTqNZGRv5Yj1dHn8WBTvs=",
         "owner": "akirak",
         "repo": "nix-org-babel",
-        "rev": "629afa44081d88ecca304ee3a2be788059026ae3",
+        "rev": "3adb6617b1bab46545ce375c07780fc01df83284",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -180,6 +180,19 @@
                   files = "emacs-config\.org$";
                   pass_filenames = true;
                 };
+                push-emacs-binary = {
+                  enable = true;
+                  name = "Push the Emacs binary";
+                  stages = [ "push" ];
+                  entry = "${
+                    channels.nixpkgs.writeShellScript "push-emacs-binary" ''
+                      result=$(timeout 3 nix eval --raw .#emacs-full.emacs) \
+                        && timeout 5 cachix push akirak "$result"
+                    ''
+                  }";
+                  files = "^flake\.lock$";
+                  pass_filenames = false;
+                };
               };
             }) shellHook;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,19 @@
     org-babel.url = "github:akirak/nix-org-babel";
     twist.url = "github:akirak/emacs-twist/devel";
     emacs-inventories.url = "path:./emacs/inventories";
+
+    # pre-commit
+    pre-commit-hooks = {
+      url = "github:cachix/pre-commit-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "utils";
+    };
+    flake-no-path = {
+      url = "github:akirak/flake-no-path";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "utils";
+      inputs.pre-commit-hooks.follows = "pre-commit-hooks";
+    };
   };
 
   outputs =
@@ -90,6 +103,7 @@
 
       outputsBuilder = channels:
         let
+          inherit (channels.nixpkgs) system;
           inherit (channels.nixpkgs) emacsConfigurations;
           emacs-full = emacsConfigurations.full;
           emacs-basic = emacsConfigurations.basic;
@@ -137,6 +151,38 @@
                 drv = emacs-full.update.writeToDir "emacs/sources";
               };
             };
+
+          # Set up a pre-commit hook by running `nix develop`.
+          devShell = channels.nixpkgs.mkShell {
+            inherit (inputs.pre-commit-hooks.lib.${system}.run {
+              src = ./.;
+              hooks = {
+                nixpkgs-fmt.enable = true;
+                # nix-linter.enable = true;
+                flake-no-path = {
+                  enable = true;
+                  name = "Ensure that flake.lock does not contain a local path";
+                  entry = "${
+                    inputs.flake-no-path.packages.${system}.flake-no-path
+                  }/bin/flake-no-path";
+                  files = "flake\.lock$";
+                  pass_filenames = true;
+                };
+                emacs-config = {
+                  enable = true;
+                  name = "Update the documentation of the Emacs configuration";
+                  stages = [ "push" ];
+                  entry = "${
+                    (channels.nixpkgs.emacsPackagesFor emacs-full.emacs).emacsWithPackages
+                      (epkgs: [ epkgs.org-make-toc ])
+                  }/bin/emacs --batch -l ${./scripts/update-emacs-config.el}
+ -f akirak/batch-update-emacs-config";
+                  files = "emacs-config\.org$";
+                  pass_filenames = true;
+                };
+              };
+            }) shellHook;
+          };
         };
 
       #########################################################

--- a/scripts/update-emacs-config.el
+++ b/scripts/update-emacs-config.el
@@ -1,0 +1,44 @@
+;;; ---  -*- lexical-binding: t -*-
+
+(require 'org)
+(require 'org-make-toc)
+
+;; Copied from
+;; <https://github.com/akirak/trivial-elisps/blob/master/akirak-org.el>
+(defun akirak-org-sort-buffer ()
+  "Sort entries in the buffer according to sorting_type property values."
+  (interactive)
+  (org-with-wide-buffer
+   (goto-char (point-min))
+   (while (re-search-forward (org-re-property "sorting_type") nil t)
+     (let ((line (thing-at-point 'line t)))
+       (if (string-match org-property-re line)
+           (org-save-outline-visibility nil
+             (org-sort-entries nil
+                               (thread-last (match-string 3 line)
+                                 (string-to-list)
+                                 (car))))
+         (error "Property didn't match")))
+     (goto-char (org-entry-end-position)))))
+
+(defun akirak/batch-update-emacs-config ()
+  "Update the Emacs configuration."
+  (let (changed)
+    (dolist (file command-line-args-left)
+      (let ((enable-local-variables nil)
+            (make-backup-files nil)
+            initial-content)
+        (find-file file)
+        (setq initial-content (sha1 (current-buffer)))
+        (akirak-org-sort-buffer)
+        (org-update-all-dblocks)
+        (when (ignore-errors
+                (goto-char (org-babel-find-named-block "tag-statistics")))
+          (org-ctrl-c-ctrl-c))
+        (org-make-toc)
+        (unless (equal (sha1 (current-buffer)) initial-content)
+          (setq changed (or changed t))
+          (message "File %s has been changed." file)
+          (save-buffer))
+        (kill-buffer)))
+    (kill-emacs (if changed 1 0))))


### PR DESCRIPTION
Changes:

- Import my previous settings of the built-in features of Emacs. 
- Further improve the infrastructure of the config development. Most notably pushing the Emacs executable to cachix, but also the tag statistics.

Notes:

- `compilation-error-regexp-alist` entries are ugly. It would be better to define a setup macro for this.
- The startup time has slowed down (~ 0.27 sec to ~ 0.33 sec). Pre byte-compiling the configuration may reduce the time for macro expansions, but I am not sure if it is the right thing to do.