### PR TITLE
ci: Add a workflow for updating ELPAs

### DIFF
--- a/.github/workflows/update-registries.yml
+++ b/.github/workflows/update-registries.yml
@@ -1,0 +1,26 @@
+name: Update Emacs Lisp package registries
+
+on:
+  push:
+    branches: develop
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: develop
+    - uses: cachix/install-nix-action@v26
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - run: nix flake update gnu-elpa nongnu-elpa melpa
+    - uses: peter-evans/create-pull-request@v6
+      with:
+        base: develop
+        token: ${{ secrets.PAT_FOR_PR }}
+        title: 'deps: Update Emacs package registries'
+        branch: bot/update/elpa
+        labels: automation,update,emacs


### PR DESCRIPTION
GNU ELPA misses a revision on the default branch quite often (see the example message below from [CI](https://github.com/akirak/emacs-config/actions/runs/9240248228/job/25420321282))

> error: Cannot find Git revision 'f2007eb074389780351fb0f179f6c9e4c96f9b88' in ref 'main' of repository 'https://git.savannah.gnu.org/git/emacs/elpa.git'! Please make sure that the rev exists on the ref you've specified or add allRefs = true; to fetchGit.

This is so common in my workflow, so I will add this workflow to automatically create a PR if there is an update in GNU/nonGNU ELPA or MELPA (which is my fork).