### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   update:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/12](https://github.com/akirak/emacs-config/security/code-scanning/12)

In general, the fix is to explicitly set a `permissions` block limiting the `GITHUB_TOKEN` to the least privilege needed. For this workflow, the job only needs to read repository contents with `GITHUB_TOKEN` (e.g., for `actions/checkout`), since writing and PR creation use `secrets.PAT_FOR_PR`. Therefore, we should add `permissions: contents: read` at the job or workflow root.

The least invasive and clear change is to add a job-level `permissions` block under `jobs.update`, just above `runs-on`. This confines the permissions to this job without affecting other workflows. Concretely, in `.github/workflows/update.yml`, between lines 11 and 12, insert:

```yaml
    permissions:
      contents: read
```

This requires no new imports or external libraries; it’s purely a YAML configuration change for GitHub Actions, preserving existing behavior while constraining `GITHUB_TOKEN` to read-only contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
