### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -9,9 +9,15 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   tag:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     outputs:
       release-tag: ${{ steps.tag.outputs.release_tag }}


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/11](https://github.com/akirak/emacs-config/security/code-scanning/11)

In general, the fix is to add an explicit `permissions` block that grants only the minimal scopes needed by this workflow or by each job. This avoids the `GITHUB_TOKEN` inheriting possibly broad default write access from the repository or organization.

For this specific workflow, the `tag` job needs to: (1) read repository contents for `actions/checkout` and `git log`, and (2) create and push tags, which requires `contents: write`. The `release` job is a reusable workflow invocation; unless you know it needs additional scopes, it can safely receive `contents: read` only (the called workflow can further refine its own permissions). The least invasive fix is to add a top-level `permissions` block that sets a safe default (e.g., `contents: read`) and then override permissions for the `tag` job to allow `contents: write`. This preserves existing behavior (tag creation and push still succeed) while reducing default privileges.

Concretely:
- In `.github/workflows/tag-release.yml`, add at the root level (alongside `name` and `on`) a `permissions:` section setting `contents: read`.
- Inside the `tag` job, add a `permissions:` section granting `contents: write`.
- Leave the `release` job without its own permissions so it inherits the safer root-level `contents: read` unless `release.yml` specifies otherwise.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
