### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-develop.yml
+++ b/.github/workflows/merge-develop.yml
@@ -5,6 +5,9 @@ on:
     types:
     - closed
 
+permissions:
+  contents: write
+
 jobs:
   tag-release:
     if: |


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/1](https://github.com/akirak/emacs-config/security/code-scanning/1)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal scopes required for the jobs, rather than relying on repository defaults. For this workflow, the `recreate_develop` job needs to push to the repository, so it requires `contents: write`. The other two jobs (`tag-release` and `update_packages`) are reusable workflows; their internal needs should be handled in their own files, but this caller workflow should still avoid unnecessarily broad permissions. The safest, least‑privilege change that preserves existing behavior is to define a workflow‑level `permissions` block granting `contents: write`, which is needed for the `git push` in `recreate_develop` (and will also be sufficient for typical tag/branch operations in the called workflows). If later you want finer granularity, you can override `permissions` per job, but that would be outside the shown snippet.

Concretely, edit `.github/workflows/merge-develop.yml` to insert a `permissions:` block near the top, after the `on:` section and before `jobs:`. The block should minimally be:

```yaml
permissions:
  contents: write
```

No imports or additional methods are required, since this is a YAML configuration change only. We do not need to alter the jobs themselves; defining workflow‑level permissions will apply to all jobs that do not specify their own `permissions:` block, which matches the current structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
