### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   update:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/10](https://github.com/akirak/emacs-config/security/code-scanning/10)

In general, the fix is to add an explicit `permissions` block either at the workflow root (applies to all jobs) or under the specific job, granting only the scopes needed. This documents what the workflow requires and ensures consistent behavior regardless of repository-level defaults.

For this workflow, the `update` job checks out code, runs `nix run .#update-ai-models` (which presumably modifies files), and uses `peter-evans/create-pull-request` to create a PR from a branch. The checkout and file updates require `contents: write` if they were to use `GITHUB_TOKEN` for pushing, though the action uses a PAT for Git operations. Still, the minimal safe and functional configuration is to restrict `GITHUB_TOKEN` to `contents: write` and keep other scopes at their default `none`. We’ll add a `permissions` block under `jobs.update` (right above `runs-on: ubuntu-latest`) with `contents: write`. No imports or external libraries are involved, just YAML configuration in `.github/workflows/update-models.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
