### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-others.yml
+++ b/.github/workflows/update-others.yml
@@ -1,4 +1,6 @@
 name: "Update other repositories"
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/9](https://github.com/akirak/emacs-config/security/code-scanning/9)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal required permissions to `GITHUB_TOKEN`. For this workflow, the job doesn’t appear to need any write access via `GITHUB_TOKEN` (it uses `secrets.PAT` for cross-repo dispatch), so we can safely restrict `contents` to `read` and omit other scopes. To avoid changing behavior, we won’t add any new write permissions.

The single best fix is to add a `permissions:` block at the workflow root so it applies to all jobs (currently only `downstream-flakes`). Immediately after the `name:` line, add:

```yml
permissions:
  contents: read
```

This clearly documents that the workflow’s `GITHUB_TOKEN` can only read repository contents, aligning with the recommendation in the background. No imports or additional definitions are required; this is a pure YAML configuration change in `.github/workflows/update-others.yml`. No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
