### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-elisp.yml
+++ b/.github/workflows/update-elisp.yml
@@ -1,4 +1,6 @@
 name: Update elisp
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/8](https://github.com/akirak/emacs-config/security/code-scanning/8)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the root or at the job level) that grants only the minimum required permissions. For this workflow, the job checks out code, updates Nix flakes, commits, and pushes back to the repository, so it needs `contents: write` at minimum; no additional scopes (like `issues`, `pull-requests`, etc.) are used here.

The best fix with minimal functional change is to add a root-level `permissions` block just below the workflow `name:` (or above `jobs:`) so it applies to all jobs. Since only repository contents are modified, we can set:
```yaml
permissions:
  contents: write
```
No other permissions are necessary based on the shown steps. Concretely, in `.github/workflows/update-elisp.yml`, insert these two lines after line 1 (or before `on:`), maintaining indentation rules for root keys. No imports or external dependencies are required; GitHub Actions understands the `permissions` key natively.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
