### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -9,6 +9,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/7](https://github.com/akirak/emacs-config/security/code-scanning/7)

In general, the fix is to add an explicit `permissions` block to the workflow (either globally at the top level or per job) that grants only the scopes needed. For this workflow, the `tag` job needs to push tags, which requires `contents: write`. The `release` job is a reusable workflow call; since we can’t see its implementation here, the safest minimal change is to set workflow-level permissions so both jobs inherit only `contents: write` (and no broader scopes).

The best fix without changing existing functionality is to add a top-level `permissions` block under the workflow `name`/`on` section, before `jobs:`, setting `contents: write`. This ensures the `GITHUB_TOKEN` has just enough permission for `git push` and avoids silently inheriting broader repository defaults. No imports or additional methods are needed, only a YAML addition in `.github/workflows/tag-release.yml`.

Concretely:
- Edit `.github/workflows/tag-release.yml`.
- Insert:

```yaml
permissions:
  contents: write
```

between the `on:` block and the `jobs:` block (e.g., after line 11 and before line 12). This will apply to both `tag` and `release` jobs that don’t override `permissions`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
