### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-emacs.yml
+++ b/.github/workflows/build-emacs.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: '${{ github.workflow }}-${{ github.ref }}'
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/6](https://github.com/akirak/emacs-config/security/code-scanning/6)

In general, the fix is to explicitly declare a minimal `permissions` block for the workflow or for individual jobs so that the GITHUB_TOKEN has only the rights required. For pure build/check jobs that only need to read the repository contents, `contents: read` is usually sufficient.

For this specific workflow, both `deps-check` and `build` jobs only check out code and run Nix builds. They do not appear to interact with issues, pull requests, or write back to the repository. The least-privilege change is to add a top-level `permissions` block (right after the `on:` or `concurrency:` sections) that applies to all jobs and sets `contents: read`. This documents the intended permission level and ensures the jobs will remain restricted even if repo defaults change.

Concretely:
- Edit `.github/workflows/build-emacs.yml`.
- Add:

  ```yaml
  permissions:
    contents: read
  ```

  at the workflow root level, between the `on:` block and `concurrency:` (or just after `concurrency:`; root position order does not affect semantics, but placing it near the top improves visibility).
- No additional imports or external dependencies are needed, as this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
