### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-develop.yml
+++ b/.github/workflows/merge-develop.yml
@@ -5,6 +5,9 @@ on:
     types:
     - closed
 
+permissions:
+  contents: read
+
 jobs:
   tag-release:
     if: |
@@ -24,6 +27,8 @@ jobs:
       github.base_ref == 'master' &&
       github.head_ref == 'develop' &&
       github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/5](https://github.com/akirak/emacs-config/security/code-scanning/5)

In general, the fix is to add an explicit `permissions:` block that limits the GITHUB_TOKEN to the minimum required scopes. This can be applied at the workflow root (affecting all jobs) and, if needed, overridden or expanded at the job level for jobs that require additional rights.

For this workflow, a good minimal, non-breaking approach is:
- Add a root-level `permissions:` block that sets `contents: read`. This documents that, by default, jobs only need read access to repository contents.
- Override this in the `recreate_develop` job, which runs `git push origin HEAD` and therefore needs to be able to write to the repository. For that job, add `permissions: contents: write`.
- The `tag-release` and `update_packages` jobs are reusable workflows. Their concrete permissions should ideally be defined inside those referenced workflows; from this file’s perspective, giving them only `contents: read` by default at the root is safe and consistent with least privilege while not changing behavior if the called workflows already request more.

Concretely:
- Edit `.github/workflows/merge-develop.yml`.
- Insert a root-level `permissions:` block after the `on:` section.
- Insert a `permissions:` block inside the `recreate_develop` job (after the `if:` condition and before `runs-on:`) specifying `contents: write`.
No imports or external dependencies are needed, just YAML changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
