### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-emacs.yml
+++ b/.github/workflows/build-emacs.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: '${{ github.workflow }}-${{ github.ref }}'
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/4](https://github.com/akirak/emacs-config/security/code-scanning/4)

In general, the fix is to explicitly set a minimal `permissions` block for this workflow or for each job, so that the `GITHUB_TOKEN` is restricted to only what is needed. Since this workflow only checks out code and runs builds, it only needs read access to repository contents.

The best fix with no functional change is to add a workflow-level `permissions` block near the top of `.github/workflows/build-emacs.yml`, under the `on:` section and before `concurrency:`. This will apply to both `deps-check` and `build` jobs. Set `contents: read`, which is sufficient for `actions/checkout` and for the rest of the steps that just execute `nix` commands. No imports or additional methods are needed; this is purely a YAML configuration change.

Concretely, edit `.github/workflows/build-emacs.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (ending at line 8) and the `concurrency:` block (starting at line 10). Leave all existing job definitions and steps unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
