### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-develop.yml
+++ b/.github/workflows/merge-develop.yml
@@ -1,5 +1,8 @@
 name: Post-merge tasks
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:
@@ -25,6 +28,8 @@ jobs:
       github.head_ref == 'develop' &&
       github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/3](https://github.com/akirak/emacs-config/security/code-scanning/3)

In general, the fix is to explicitly define `permissions:` for the workflow or for individual jobs, granting only the scopes they actually need. A safe pattern is to set restrictive defaults at the workflow root (e.g., `contents: read`) and then override specific jobs with broader permissions (e.g., `contents: write`) if they must push commits or tags.

For this specific file, add a workflow-level `permissions:` block after the `name:` line and before `on:` that sets `contents: read` as the default. Then, for the `recreate_develop` job, which runs `git push origin HEAD`, add a `permissions:` block under that job to elevate its token to `contents: write`. The two jobs that call reusable workflows (`tag-release` and `update_packages`) can continue to rely on the called workflows’ own permission definitions; if those called workflows require more than `contents: read`, they should declare it themselves. No imports or external dependencies are needed—only YAML changes in `.github/workflows/merge-develop.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
