### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/2](https://github.com/akirak/emacs-config/security/code-scanning/2)

In general, the fix is to add an explicit `permissions:` block to the workflow or to the specific job, limiting `GITHUB_TOKEN` to the minimal scopes required. For this workflow, the steps read repository contents and upload release assets. That implies we need `contents: read` so `actions/checkout` can function, and write access to releases (`contents: write` or `contents: write` plus optionally `id-token: write` etc. if needed). The `akirak/action-gh-release` action uses the standard `GITHUB_TOKEN` to create or update releases and upload assets, which requires `contents: write`. No other scopes (issues, pull-requests, packages, etc.) are used here.

The single best way to fix this without changing existing functionality is to add a workflow-level `permissions:` block near the top of `.github/workflows/release.yml`, after the `on:` section (or at the root anywhere before `jobs:`), specifying:
```yaml
permissions:
  contents: write
```
This keeps the ability to create/update releases while limiting the token to repository contents only. Since there is only one job and it uses `checkout` and a release-upload action, a global `permissions:` is simpler and correctly applies to the job at line 20 where CodeQL raised the issue.

Concretely:
- Edit `.github/workflows/release.yml`.
- Insert a `permissions:` block at the root level (same indentation as `on:` and `jobs:`), for example between the `workflow_call` block and `concurrency`, or between `on:` and `concurrency`.
- No imports or additional methods are required; this is purely YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
