### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-develop.yml
+++ b/.github/workflows/merge-develop.yml
@@ -39,5 +39,7 @@ jobs:
 
   update_packages:
     needs: recreate_develop
+    permissions:
+      contents: read
     uses: ./.github/workflows/update-elisp.yml
     secrets: inherit


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/5](https://github.com/akirak/emacs-config/security/code-scanning/5)

In general, the problem is fixed by explicitly defining a `permissions` block at the workflow root or for each job, so the GITHUB_TOKEN has only the minimum necessary access. This workflow already sets `permissions` for `recreate_develop`, so the least-intrusive change is to add an explicit `permissions` block to the `update_packages` job as well.

The best targeted fix here is to add a `permissions` block under `update_packages:` at the same indentation level as `needs`, `uses`, and `secrets`. Since we do not know what `update-elisp.yml` requires, we should start with a minimal, documented baseline such as `contents: read`, which is equivalent to a read-only default for repo contents and is a common safe starting point. If `update-elisp.yml` internally requires more (for example, `contents: write` or `pull-requests: write`), that can be adjusted there or here later, but adding `contents: read` already resolves the CodeQL finding by constraining the token.

Concretely:
- Edit `.github/workflows/merge-develop.yml`.
- In the `update_packages` job definition (around lines 40–43), insert:

```yaml
    permissions:
      contents: read
```

between `needs: recreate_develop` and `uses: ./.github/workflows/update-elisp.yml`, maintaining indentation. No imports or additional methods are required since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
