### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-develop.yml
+++ b/.github/workflows/merge-develop.yml
@@ -5,6 +5,9 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+
 jobs:
   tag-release:
     if: |


### PR DESCRIPTION
Potential fix for [https://github.com/akirak/emacs-config/security/code-scanning/1](https://github.com/akirak/emacs-config/security/code-scanning/1)

To fix the issue, the workflow should declare explicit GITHUB_TOKEN permissions rather than relying on the repository defaults. The least-privilege approach is to add a top-level `permissions` block that applies to all jobs, and then only override it in jobs that need more access. In this file, `recreate_develop` already has `contents: write`, so we can set a restrictive default (e.g., `contents: read`) at the root and keep the job-specific override as-is.

Concretely:
- Add a `permissions:` section near the top of `.github/workflows/merge-develop.yml`, at the same indentation level as `on:` and `jobs:`, specifying minimal read-only permissions such as `contents: read`.
- Do not modify the existing `permissions:` block under `recreate_develop`, since it already declares the necessary `contents: write` scope.
- This ensures `tag-release` and `update_packages` run with restricted read-only permissions (unless their called workflows override them internally), and it satisfies the CodeQL rule without changing functional behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
